### PR TITLE
Lock version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM offen/offen:latest
+FROM offen/offen:v0.1.0-alpha.3
 
 CMD ["serve"]


### PR DESCRIPTION
Alpha 3 will include all fixes and features necessary for a smooth Heroku deployment, so this can be locked once it's officially released.